### PR TITLE
Add project name (variable pjname) definition at the top of the modul…

### DIFF
--- a/core/buildmonitor/viewsci.py
+++ b/core/buildmonitor/viewsci.py
@@ -29,6 +29,7 @@ def civiewDemo(request):
         rname = request.session['requestParams']['rel']
     else:
         rname = '*'
+    pjname = '*'
 
     new_cur = connection.cursor()
     check_icon='<div class="ui-widget ui-state-check" style="display:inline-block;"> <span s\

--- a/core/buildmonitor/viewsn.py
+++ b/core/buildmonitor/viewsn.py
@@ -29,6 +29,8 @@ def nviewDemo(request):
         rname = request.session['requestParams']['rel']
     else:
         rname = '*'
+    ar_sel="unknown"
+    pjname='unknown'
 
     new_cur = connection.cursor()
     dict_from_cache = cache.get('art-monit-dict')


### PR DESCRIPTION
…e to prevent errors of "reference before assignment" (which occurred when users made misprint in URLs indicating, for instance, invalid release names)