### PR TITLE
Removed groups from user_details in oidc/indigoiam

### DIFF
--- a/core/oauth/indigoiam.py
+++ b/core/oauth/indigoiam.py
@@ -29,7 +29,6 @@ class IndigoIamOIDC(BaseOAuth2):
             'first_name': response.get('given_name', ''),
             'last_name': response.get('family_name', ''),
             'name': response.get('name', ''),
-            'groups': response.get('groups', []),
         }
     def user_data(self, access_token, *args, **kwargs):
         return self.get_json(urljoin(self.setting('BASEPATH'), 'userinfo'),


### PR DESCRIPTION
To fix a crash in social_auth like

  File "/opt/bigmon/lib64/python3.6/site-packages/social_core/pipeline/user.py", line 123, in user_details
    setattr(user, name, value)
  File "/opt/bigmon/lib64/python3.6/site-packages/django/db/models/fields/related_descriptors.py", line 538, in __set__
    % self._get_set_deprecation_msg_params(),
TypeError: Direct assignment to the forward side of a many-to-many set is prohibited. Use groups.set() instead.