### PR TITLE
drop maxattempt# on job pages

### DIFF
--- a/core/templates/jobInfo.html
+++ b/core/templates/jobInfo.html
@@ -429,7 +429,7 @@
 	{% if job.transfertype %}<tr><th>Transfer type</th><td>{{ job.transfertype }}</td></tr>{% endif %}
 	{% if job.specialhandling %}<tr><th>Special handling</th><td>{{ job.specialhandling }}</td></tr>{% endif %}
 	{% if job.nevents %}<tr><th># events</th><td>{{ job.nevents }}</td></tr>{% endif %}
-	{% if job.attemptnr %}<tr><th>Attempt number</th><td>{{ job.attemptnr }} of a maximum {{ job.maxattempt }}</td></tr></tr>{% endif %}
+	{% if job.attemptnr %}<tr><th>Attempt number</th><td>{{ job.attemptnr }}</td></tr></tr>{% endif %}
 	{% if job.destinationse %}<tr><th>Output destination</th><td>{{ job.destinationse }}</td></tr>{% endif %}
 	{% if job.cpuconsumptiontime %}<tr><th>CPU consumption time (s)</th><td>{{ job.cpuconsumptiontime }}</td></tr>{% endif %}
 	{% if job.jobmetrics %}<tr><th>Job metrics</th><td>{{ job.jobmetrics }}</td></tr>{% endif %}
@@ -469,12 +469,14 @@
 </thead>
 <tbody>
 {% for col in columns %}
+{% if col.name != 'maxattempt' %}
 <tr>
   <th>{{ col.name }}</th>
   <td> {% if col.name == 'jobsetid' %} <a href="{% url 'jobList' %}?produsername={{ produsername }}&jobsetid={{ col.value }}">{{ col.value }}</a>
     {% elif col.name != 'metastruct' %}{{ col.value }} {% else %} {% endif %}
   </td>
 </tr>
+{% endif %}
 {% endfor %}
 </tbody>
 </table>

--- a/core/templates/jobInfoES.html
+++ b/core/templates/jobInfoES.html
@@ -381,7 +381,7 @@
 	{% if job.transfertype %}<tr><th>Transfer type</th><td>{{ job.transfertype }}</td></tr>{% endif %}
 	{% if job.specialhandling %}<tr><th>Special handling</th><td>{{ job.specialhandling }}</td></tr>{% endif %}
 	{% if job.nevents %}<tr><th># events</th><td>{{ job.nevents }}</td></tr>{% endif %}
-	{% if job.attemptnr %}<tr><th>Attempt number</th><td>{{ job.attemptnr }} of a maximum {{ job.maxattempt }}</td></tr></tr>{% endif %}
+	{% if job.attemptnr %}<tr><th>Attempt number</th><td>{{ job.attemptnr }}</td></tr></tr>{% endif %}
 	{% if job.destinationse %}<tr><th>Output destination</th><td>{{ job.destinationse }}</td></tr>{% endif %}
 	{% if job.cpuconsumptiontime %}<tr><th>CPU consumption time (s)</th><td>{{ job.cpuconsumptiontime }}</td></tr>{% endif %}
 	{% if job.jobmetrics %}<tr><th>Job metrics</th><td>{{ job.jobmetrics }}</td></tr>{% endif %}
@@ -421,12 +421,14 @@
 </thead>
 <tbody>
 {% for col in columns %}
-<tr>
+{% if col.name != 'maxattempt' %}
+<tr>  
   <th>{{ col.name }}</th>
   <td> {% if col.name == 'jobsetid' %} <a href="{% url 'jobList' %}?produsername={{ produsername }}&jobsetid={{ col.value }}">{{ col.value }}</a>
     {% elif col.name != 'metastruct' %}{{ col.value }} {% else %} {% endif %}
   </td>
 </tr>
+{% endif %}
 {% endfor %}
 </tbody>
 </table>

--- a/core/templates/jobList.html
+++ b/core/templates/jobList.html
@@ -295,7 +295,7 @@ time since last state change, <a href="{{nosorturl}}sortby=create-ascending">asc
 {% endif %}
 </th></tr>
 <tr class='tablesection'>
-	<th>PanDA ID<br>Attempt# of maxAttempts#{% if requestParams.fileid %}<br><span style="color: gray">FileAttempt# of maxFileAttempt</span>{% endif %}</th>
+	<th>PanDA ID<br>Attempt#{% if requestParams.fileid %}<br><span style="color: gray">FileAttempt#</span>{% endif %}</th>
 	<th>Owner {% if viewParams.MON_VO != 'ATLAS' %} / VO{% endif %}<br>Group  </th>
 	<th>Request<br>Task ID</th>
 	<th>Transformation</th>
@@ -312,8 +312,8 @@ time since last state change, <a href="{{nosorturl}}sortby=create-ascending">asc
 </tr>
     {% for job in jobList %}
 	<tr {% if job.jobstatus == 'failed'%} class="failedjob" {% endif %}>
-		<td rowspan=3><a href="{% url 'jobInfo' %}?pandaid={{ job.pandaid }}">{{ job.pandaid }}</a><br>Attempt {{ job.attemptnr }} of {{ job.maxattempt }}
-			{% if requestParams.fileid %}<br><span style="color: gray">FileAttempt {% if job.fileattemptnr or job.filemaxattempts %}{{ job.fileattemptnr }} of {{ job.filemaxattempts }}{% endif %}</span>{% endif %}
+		<td rowspan=3><a href="{% url 'jobInfo' %}?pandaid={{ job.pandaid }}">{{ job.pandaid }}</a><br>Attempt {{ job.attemptnr }}
+			{% if requestParams.fileid %}<br><span style="color: gray">FileAttempt {% if job.fileattemptnr %}{{ job.fileattemptnr }}{% endif %}</span>{% endif %}
             <br>
 		    {% if job.consumer %}
 		     Consumer: <a href="{% url 'jobInfo' %}?pandaid={{ job.consumer }}">{{ job.consumer }}</a>

--- a/core/templates/jobListES.html
+++ b/core/templates/jobListES.html
@@ -262,7 +262,7 @@ Sort by
 </font>
 </th></tr>
 <tr class='tablesection'>
-	<th>PanDA ID<br>Attempt# of maxAttempts#{% if requestParams.fileid %}<br><span style="color: gray">FileAttempt# of maxFileAttempt</span>{% endif %}</th>
+	<th>PanDA ID<br>Attempt#{% if requestParams.fileid %}<br><span style="color: gray">FileAttempt#</span>{% endif %}</th>
 	<th>Owner {% if viewParams.MON_VO != 'ATLAS' %} / VO{% endif %}<br>Group  </th>
 	<th>Task ID</th>
 	<th>Transformation</th>
@@ -281,8 +281,8 @@ Sort by
 </tr>
     {% for job in jobList %}
 	<tr>
-		<td rowspan=3><a href="{% url 'jobInfo' %}?pandaid={{ job.pandaid }}">{{ job.pandaid }}</a><br>Attempt {{ job.attemptnr }} of {{ job.maxattempt }}
-            {% if requestParams.fileid %}<br><span style="color: gray">FileAttempt {% if job.fileattemptnr or job.filemaxattempts %}{{ job.fileattemptnr }} of {{ job.filemaxattempts }}{% endif %}</span>{% endif %}
+		<td rowspan=3><a href="{% url 'jobInfo' %}?pandaid={{ job.pandaid }}">{{ job.pandaid }}</a><br>Attempt {{ job.attemptnr }}
+            {% if requestParams.fileid %}<br><span style="color: gray">FileAttempt {% if job.fileattemptnr %}{{ job.fileattemptnr }}{% endif %}</span>{% endif %}
             <br>
             {% if job.consumer %}
 		     Consumer: <a href="{% url 'jobInfo' %}?pandaid={{ job.consumer }}">{{ job.consumer }}</a>


### PR DESCRIPTION
I still allow the model.py to read maxattempt, only changed the templates to drop the maxattempt#, in case the monitor still needs it somewhere.