### PR TITLE
ATLASPANDA-1470: Improve set_debug_mode to show 'message' or 'detail' from API response

### DIFF
--- a/core/panda_client/utils.py
+++ b/core/panda_client/utils.py
@@ -260,7 +260,8 @@ def set_debug_mode(request, **kwargs) -> str:
     except Exception as ex:
         return f"ERROR to set debug mode: {ex}"
 
-    return f"{status} {output}"
+    message = output.get("message", "No message")
+    return f"Status: {status}, message: {message}"
 
 
 def get_worker_stats(auth: Optional[Dict[str, str]] = None, **params) -> Tuple[int, Dict[str, Any]]:

--- a/core/panda_client/utils.py
+++ b/core/panda_client/utils.py
@@ -260,7 +260,7 @@ def set_debug_mode(request, **kwargs) -> str:
     except Exception as ex:
         return f"ERROR to set debug mode: {ex}"
 
-    message = output.get("message", "No message")
+    message = output.get("message") or output.get("detail") or str(output)
     return f"Status: {status}, message: {message}"
 
 


### PR DESCRIPTION
Updated set_debug_mode return string to extract 'message' or 'detail'  fields from API response instead of dumping the entire dictionary.  This makes output more user-friendly and ensures proper error messages (such as expired IAM token) are displayed.