### PR TITLE
Fix UnboundLocalError in get_rucio_username_by_produserid for OIDC jobs

### DIFF
--- a/core/filebrowser/rucioutils.py
+++ b/core/filebrowser/rucioutils.py
@@ -12,11 +12,11 @@ def get_rucio_username_by_produserid(produserid, prodsourcelabel='user'):
     :return: str - Rucio username
     """
     if prodsourcelabel == 'user':
+        dn = produserid
         try:
             if produserid.startswith("/"):
                 # OpenSSL -> RFC 2253 format & remove last part if it is a number (e.g. /CN=1234567890)
-                if produserid.startswith("/"):
-                    produserid = produserid[1:]
+                produserid = produserid[1:]
                 parts = produserid.split("/")
                 if parts and parts[-1].startswith("CN="):
                     value = parts[-1][3:]


### PR DESCRIPTION
## Summary

- `get_rucio_username_by_produserid()` in `core/filebrowser/rucioutils.py` crashes with `UnboundLocalError: cannot access local variable 'dn' where it is not associated with a value` when viewing a job page for an OIDC-authenticated job
- `dn` was only assigned inside the `if produserid.startswith("/"):` block (x509 DN path); for OIDC jobs `produserid` is a username/email and never enters that branch, leaving `dn` unbound
- Also removed a redundant duplicate `startswith('/')` check inside the block

## Root cause

```python
# Before: dn only set inside if-block, crashes for OIDC users
try:
    if produserid.startswith("/"):
        ...
        dn = ",".join(parts)   # never reached for OIDC
except ValueError:
    dn = produserid

rw.getRucioAccountByDN(dn)  # UnboundLocalError for OIDC jobs
```

## Fix

Initialize `dn = produserid` before the `if` block as a safe default:

```python
dn = produserid  # default for non-x509 producers (OIDC, usernames, emails)
try:
    if produserid.startswith("/"):
        ...
        dn = ",".join(parts)
```

## Impact

The `/job?pandaid=<id>` page returned HTTP 500 ("Oops, something went wrong") for any job submitted via OIDC token auth. The fix makes the page load correctly, passing the raw `produserid` to `getRucioAccountByDN` as the fallback when no x509 DN conversion is needed.